### PR TITLE
feat(core): add apiRoute helper for resource-based endpoints

### DIFF
--- a/core/apiRoute.js
+++ b/core/apiRoute.js
@@ -1,0 +1,54 @@
+// core/apiRoute.js
+// Provide a simple helper to create RESTful resource routes.
+// Internally uses addRoute(app, basePath, handlers).
+// - resource: string like 'users' or '/users'
+// - handlers: function (assumed GET) or an object mapping methods and/or nested subpaths
+
+const addRoute = require('./addRoute');
+
+/**
+ * Normalize resource into a base path string.
+ * @param {string} resource
+ * @returns {string} normalized path starting with '/'
+ */
+function normalizeResource(resource) {
+  if (!resource) return '/';
+  if (typeof resource !== 'string') {
+    throw new Error('resource must be a string');
+  }
+  // trim trailing slash, ensure leading slash
+  let r = resource.trim();
+  if (!r.startsWith('/')) r = '/' + r;
+  if (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
+  return r;
+}
+
+/**
+ * apiRoute(app, resource, handlers)
+ * @param {Object} app - Express app (Kaelum app)
+ * @param {string} resource - resource name or path (e.g. 'users' or '/users')
+ * @param {Function|Object} handlers - function or object with methods and/or nested subpaths
+ */
+function apiRoute(app, resource, handlers = {}) {
+  if (!app || typeof app.use !== 'function') {
+    throw new Error('Invalid app instance: cannot register apiRoute');
+  }
+
+  const basePath = normalizeResource(resource);
+
+  // If handlers is a function, assume it's a GET on basePath
+  if (typeof handlers === 'function') {
+    addRoute(app, basePath, handlers);
+    return;
+  }
+
+  // If handlers is not an object, throw
+  if (!handlers || typeof handlers !== 'object') {
+    throw new Error('Handlers must be a function or a plain object');
+  }
+
+  // Directly reuse addRoute: it supports method keys and nested '/:id' subpaths.
+  addRoute(app, basePath, handlers);
+}
+
+module.exports = apiRoute;

--- a/createApp.js
+++ b/createApp.js
@@ -10,6 +10,7 @@ const path = require("path");
 
 const start = require("./core/start");
 const addRoute = require("./core/addRoute");
+const apiRoute = require("./core/apiRoute");
 const setMiddleware = require("./core/setMiddleware");
 const coreSetConfig = require("./core/setConfig");
 
@@ -85,6 +86,12 @@ function createApp() {
   if (typeof addRoute === "function") {
     app.addRoute = function (routePath, handlers) {
       return addRoute(app, routePath, handlers);
+    };
+  }
+
+  if (typeof apiRoute === "function") {
+    app.apiRoute = function (resource, handlers) {
+      return apiRoute(app, resource, handlers);
     };
   }
 


### PR DESCRIPTION
## Summary

Adds `apiRoute` to Kaelum core — a helper that simplifies creation of RESTful resource endpoints.
The helper normalizes a resource name into a base path and delegates to the existing `addRoute` implementation,
supporting top-level method handlers and nested subpaths (e.g. '/:id').

## Files changed
- core/apiRoute.js (new)
- createApp.js (expose app.apiRoute)

## How to test
1. Link the local package:
```

# inside Kaelum repo

npm link

# inside a template project

npm link kaelum

```

2. Run the app and exercise endpoints:
```

curl [http://localhost:3000/users](http://localhost:3000/users)
curl -X POST [http://localhost:3000/users](http://localhost:3000/users) -H "Content-Type: application/json" -d '{}'
curl [http://localhost:3000/users/1](http://localhost:3000/users/1)
curl [http://localhost:3000/health](http://localhost:3000/health)

```

## Checklist
- [x] Implemented apiRoute core helper
- [x] Exposed app.apiRoute in createApp
- [ ] Added example in template routes
- [ ] Update README with apiRoute docs (follow-up)