### PR TITLE
feat(core): add generic errorHandler middleware and expose app.useErrorHandler()

### DIFF
--- a/core/errorHandler.js
+++ b/core/errorHandler.js
@@ -1,0 +1,49 @@
+// core/errorHandler.js
+// Generic error handling middleware factory for Kaelum.
+//
+// Usage:
+//   const { errorHandler } = require('./core/errorHandler');
+//   app.use(errorHandler({ exposeStack: false }));
+//
+// The middleware responds with JSON:
+//   { error: { message: "...", code: "SOME_CODE" [, stack: "..." ] } }
+// - status is taken from err.status or err.statusCode or defaults to 500
+// - err.code is used if present; otherwise "INTERNAL_ERROR"
+
+function errorHandler(options = {}) {
+  const { exposeStack = false } = options;
+
+  return function (err, req, res, next) {
+    // If headers already sent, delegate to default Express handler
+    if (res.headersSent) {
+      return next(err);
+    }
+
+    const status = (err && (err.status || err.statusCode)) ? (err.status || err.statusCode) : 500;
+
+    const payload = {
+      error: {
+        message: (err && err.message) ? err.message : 'Internal Server Error',
+        code: (err && err.code) ? err.code : 'INTERNAL_ERROR'
+      }
+    };
+
+    if (exposeStack && err && err.stack) {
+      payload.error.stack = err.stack;
+    }
+
+    // Server-side logging: errors 5xx -> console.error, others -> console.warn
+    if (status >= 500) {
+      // prefer stack if available
+      if (err && err.stack) console.error(err.stack);
+      else console.error(err);
+    } else {
+      if (err && err.message) console.warn(err.message);
+      else console.warn(err);
+    }
+
+    res.status(status).json(payload);
+  };
+}
+
+module.exports = { errorHandler };


### PR DESCRIPTION
## Summary

Adds a generic, configurable error handling middleware to Kaelum:

- `core/errorHandler.js` exports `errorHandler(options)` factory.
- `createApp.js` exposes `app.useErrorHandler(options)` and alias `app.errorHandler`.
- Example routes updated in templates to demonstrate throwing and next(err) usage.

## Behavior

- Default response format:
  {
    "error": {
      "message": "...",
      "code": "SOME_CODE"
    }
  }
- Status code is taken from `err.status` or `err.statusCode`, default 500.
- `options.exposeStack = true` will include `error.stack` in the response (useful for local dev).
- The middleware is idempotent (previous Kaelum-installed handler is removed before installing a new one).

## How to test

1. Link package locally (`npm link`) and run a template app:
```

node app.js

```

2. Exercise endpoints:
```

curl [http://localhost:3000/boom](http://localhost:3000/boom)
curl -i [http://localhost:3000/bad](http://localhost:3000/bad)

```

## Checklist

- [x] Add errorHandler middleware factory
- [x] Expose app.useErrorHandler() / app.errorHandler()
- [ ] Add unit tests (follow-up)
- [ ] Update README and Notion docs