### PR TITLE
feat(core): add healthCheck helper and expose app.healthCheck()

### DIFF
--- a/core/healthCheck.js
+++ b/core/healthCheck.js
@@ -1,0 +1,52 @@
+// core/healthCheck.js
+// Simple health-check route helper for Kaelum.
+// Usage: registerHealth(app, '/health')
+
+/**
+ * Register a health-check endpoint.
+ * @param {Object} app - Express/Kaelum app instance
+ * @param {string} routePath - route path (default '/health')
+ */
+function registerHealth(app, routePath = "/health") {
+  if (!app || typeof app.get !== "function") {
+    throw new Error("Invalid app instance: cannot register health check");
+  }
+
+  const p =
+    typeof routePath === "string"
+      ? routePath.startsWith("/")
+        ? routePath
+        : "/" + routePath
+      : "/health";
+
+  // Remove any previous handler for the same path if present to avoid duplication.
+  // We'll be conservative and not remove other handlers globally.
+  try {
+    // If there is already an identical layer, skip adding another.
+    const existing =
+      app._router && Array.isArray(app._router.stack)
+        ? app._router.stack.find(
+            (layer) =>
+              layer.route &&
+              layer.route.path === p &&
+              layer.route.methods &&
+              layer.route.methods.get
+          )
+        : null;
+    if (existing) return;
+  } catch (e) {
+    // ignore internal inspection failures and proceed to register
+  }
+
+  app.get(p, (req, res) => {
+    res.json({
+      status: "OK",
+      uptime: process.uptime(),
+      timestamp: Date.now(),
+      pid: process.pid,
+      env: process.env.NODE_ENV || "development",
+    });
+  });
+}
+
+module.exports = registerHealth;

--- a/createApp.js
+++ b/createApp.js
@@ -15,6 +15,7 @@ const apiRoute = require("./core/apiRoute");
 const setMiddleware = require("./core/setMiddleware");
 const coreSetConfig = require("./core/setConfig");
 const { errorHandler } = require("./core/errorHandler");
+const registerHealth = require("./core/healthCheck");
 
 function createApp() {
   const app = express();
@@ -83,8 +84,15 @@ function createApp() {
 
   // remove middleware by matching the function reference from the express internal stack
   function removeMiddlewareByFn(appInstance, fn) {
-    if (!appInstance || !appInstance._router || !Array.isArray(appInstance._router.stack)) return;
-    appInstance._router.stack = appInstance._router.stack.filter((layer) => layer.handle !== fn);
+    if (
+      !appInstance ||
+      !appInstance._router ||
+      !Array.isArray(appInstance._router.stack)
+    )
+      return;
+    appInstance._router.stack = appInstance._router.stack.filter(
+      (layer) => layer.handle !== fn
+    );
   }
 
   // ---------------------------
@@ -115,6 +123,13 @@ function createApp() {
         return setMiddleware(app, middlewareOrPath, maybeMiddleware);
       }
       return setMiddleware(app, middlewareOrPath);
+    };
+  }
+
+  if (typeof registerHealth === "function") {
+    app.healthCheck = function (routePath = "/health") {
+      registerHealth(app, routePath);
+      return app;
     };
   }
 


### PR DESCRIPTION
## Summary
Adds a small health-check helper to Kaelum:
- core/healthCheck.js registers a GET endpoint that returns basic service info (status, uptime, pid, timestamp, env).
- createApp.js exposes app.healthCheck(routePath) for easy registration.

## How to test
1. npm link (if local) and run the template app.
2. curl http://localhost:3000/health

## Checklist
- [x] core/healthCheck.js implemented
- [x] createApp.js exposes app.healthCheck()
- [ ] Add example to templates (follow-up)
- [ ] Update README/Notion docs (follow-up)
