### PR TITLE
feat(core): finalize setConfig with port/logs/static/bodyParser and make start read config

### DIFF
--- a/core/start.js
+++ b/core/start.js
@@ -1,26 +1,27 @@
 // core/start.js
-// start(app, port?, callback?) - read port from Kaelum config if not provided
+// Start helper for Kaelum: uses port passed or reads from Kaelum config, or falls back to 3000.
 
 function start(app, port, cb) {
-  // allow start(app) or start(app, port) or start(app, port, cb)
-  // If port is not a number, shift arguments
-  let listenPort = port;
-  let callback = cb;
+  if (!app) throw new Error("start requires an app instance");
 
-  if (typeof port === 'function') {
-    callback = port;
-    listenPort = undefined;
+  // If port omitted, try to read from Kaelum config
+  let usePort = port;
+  if (typeof usePort === "undefined" || usePort === null) {
+    const cfg = app.get("kaelum:config") || app.locals.kaelumConfig || {};
+    if (cfg && cfg.port) usePort = cfg.port;
   }
+  // fallback default
+  if (typeof usePort === "undefined" || usePort === null) usePort = 3000;
 
-  const cfg = app.get('kaelum:config') || app.locals.kaelumConfig || {};
-  if (typeof listenPort !== 'number') {
-    listenPort = cfg.port || process.env.PORT || 3000;
-  }
-
-  const server = app.listen(listenPort, () => {
-    console.log(`Server running on port ${listenPort}`);
-    if (typeof callback === 'function') callback();
+  // create server and store reference for possible later use
+  const server = app.listen(usePort, () => {
+    console.log(`🚀 Kaelum server running on port ${usePort}`);
+    if (typeof cb === "function") cb();
   });
+
+  // keep reference if needed
+  if (!app.locals) app.locals = {};
+  app.locals._kaelum_server = server;
 
   return server;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "kaelum",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kaelum",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "fs-extra": "^11.3.0",
         "helmet": "^7.2.0",
-        "inquirer": "^12.6.0"
+        "inquirer": "^12.6.0",
+        "morgan": "^1.10.1"
       },
       "bin": {
         "kaelum": "cli/index.js"
@@ -379,6 +380,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -999,6 +1018,34 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1052,6 +1099,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express": "^4.18.2",
     "fs-extra": "^11.3.0",
     "helmet": "^7.2.0",
-    "inquirer": "^12.6.0"
+    "inquirer": "^12.6.0",
+    "morgan": "^1.10.1"
   }
 }


### PR DESCRIPTION
## Summary
This PR finalizes Kaelum's setConfig helper by adding:
- port persistence (setConfig({ port }))
- logs toggle using morgan (setConfig({ logs: true }))
- static folder replacement/removal (setConfig({ static: 'public' }) / static: false)
- bodyParser toggle to enable/disable default parsers
Also start() now reads port from Kaelum config if no port argument provided.

## How to test
1. npm install morgan cors helmet (in Kaelum repo)
2. Link locally or use test template
3. Call app.setConfig({ port: 4200, logs: true, static: 'public', cors: true, helmet: true })
4. app.start() should start server on configured port and enable features.

## Checklist
- [x] core/setConfig.js updated
- [x] core/start.js updated
- [x] Local manual tests done
- [ ] Update README/Notion docs (follow-up)