### PR TITLE
feat(core): add redirect helper and expose app.redirect()

### DIFF
--- a/core/redirect.js
+++ b/core/redirect.js
@@ -1,0 +1,41 @@
+// core/redirect.js
+// Helper to register simple redirect routes in Kaelum.
+// Usage: redirect(app, '/old', '/new', 302)
+// Returns the app for chaining.
+
+function redirect(app, fromPath, toPath, status = 302) {
+  if (!app || typeof app.get !== "function") {
+    throw new Error("Invalid app instance: cannot register redirect");
+  }
+  if (typeof fromPath !== "string" || typeof toPath !== "string") {
+    throw new Error("redirect: fromPath and toPath must be strings");
+  }
+
+  const from = fromPath.startsWith("/") ? fromPath : "/" + fromPath;
+
+  // Avoid duplicate registration: remove existing route with same path if present
+  try {
+    if (app._router && Array.isArray(app._router.stack)) {
+      app._router.stack = app._router.stack.filter((layer) => {
+        // keep layers that are not the same GET route
+        if (!layer.route) return true;
+        if (layer.route && layer.route.path === from) {
+          // remove old route for same path (prevents duplicates)
+          return false;
+        }
+        return true;
+      });
+    }
+  } catch (e) {
+    // If internal inspection fails, continue and add the new handler anyway
+  }
+
+  // Register a GET route that redirects
+  app.get(from, (req, res) => {
+    res.redirect(status, toPath);
+  });
+
+  return app;
+}
+
+module.exports = redirect;

--- a/createApp.js
+++ b/createApp.js
@@ -16,6 +16,7 @@ const setMiddleware = require("./core/setMiddleware");
 const coreSetConfig = require("./core/setConfig");
 const { errorHandler } = require("./core/errorHandler");
 const registerHealth = require("./core/healthCheck");
+const redirect = require("./core/redirect");
 
 function createApp() {
   const app = express();
@@ -130,6 +131,12 @@ function createApp() {
     app.healthCheck = function (routePath = "/health") {
       registerHealth(app, routePath);
       return app;
+    };
+  }
+
+  if (typeof redirect === "function") {
+    app.redirect = function (from, to, status = 302) {
+      return redirect(app, from, to, status);
     };
   }
 


### PR DESCRIPTION
## Summary
Adds a small and useful redirect helper to Kaelum:
- core/redirect.js: registers a GET route that issues an HTTP redirect.
- createApp.js: exposes app.redirect(from, to, status) for simple usage.

## How to test
1. In a test project, call:
   app.redirect('/old-page', '/new-page');
   app.addRoute('/new-page', { get: (req,res) => res.send('New') });
2. Start the app and run:
   curl -i http://localhost:3000/old-page
   # Expect 302 and Location: /new-page

## Checklist
- [x] core/redirect.js implemented
- [x] createApp.js exposes app.redirect()
- [ ] Template docs/examples updated (follow-up)
- [ ] Notion/README updated (follow-up)