### PR TITLE
refactor(core): consolidate core refactors into meta-6-part2

### DIFF
--- a/core/addRoute.js
+++ b/core/addRoute.js
@@ -1,14 +1,72 @@
 // core/addRoute.js
-// Adds routes to an Express app using a flexible handlers object
+// Adds routes to an Express app using a flexible handlers object.
 // Supports:
 // - handlers as a single function (assumed GET)
 // - handlers as an object with HTTP methods (get, post, put, delete, patch, all)
 // - nested subpaths as keys beginning with '/' (e.g. '/:id': { get: fn })
+// - handlers as arrays of functions (middleware chains)
 
-const supportedMethods = ['get', 'post', 'put', 'delete', 'patch', 'all'];
+const supportedMethods = ["get", "post", "put", "delete", "patch", "all"];
 
 function isPlainObject(v) {
-  return v && typeof v === 'object' && !Array.isArray(v);
+  return v && typeof v === "object" && !Array.isArray(v);
+}
+
+/**
+ * Normalize a handler entry into an array of functions.
+ * Acceptable inputs: function | [function, function, ...]
+ * @param {Function|Function[]} h
+ * @returns {Function[]}
+ */
+function normalizeHandlersToArray(h) {
+  if (typeof h === "function") return [h];
+  if (Array.isArray(h)) {
+    const invalid = h.find((fn) => typeof fn !== "function");
+    if (invalid) {
+      throw new Error("Each element in handler array must be a function");
+    }
+    return h;
+  }
+  throw new Error("Handler must be a function or an array of functions");
+}
+
+/**
+ * Wrap a handler function to catch thrown errors / rejected promises
+ * and forward them to next(err).
+ * @param {Function} fn
+ * @returns {Function} async wrapper (req, res, next)
+ */
+function wrapHandler(fn) {
+  return async function wrapped(req, res, next) {
+    try {
+      // support handlers that expect next as third argument
+      const maybePromise = fn(req, res, next);
+      // if handler returns a promise, await it to catch rejections
+      if (maybePromise && typeof maybePromise.then === "function") {
+        await maybePromise;
+      }
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+/**
+ * Join basePath and subKey in a safe manner (avoid duplicate slashes).
+ * @param {string} basePath
+ * @param {string} key
+ * @returns {string}
+ */
+function joinPaths(basePath, key) {
+  if (!basePath.endsWith("/")) basePath = basePath;
+  // remove trailing slash from basePath (except if basePath === '/')
+  if (basePath !== "/" && basePath.endsWith("/")) {
+    basePath = basePath.slice(0, -1);
+  }
+  // ensure key starts with '/'
+  const k = key.startsWith("/") ? key : "/" + key;
+  // special case: basePath === '/' -> result is key
+  return basePath === "/" ? k : basePath + k;
 }
 
 /**
@@ -18,22 +76,26 @@ function isPlainObject(v) {
  * @param {Function|Object} handlers - single handler function or object map of handlers
  */
 function addRoute(app, basePath, handlers = {}) {
-  if (!app || typeof app.use !== 'function') {
-    throw new Error('Invalid app instance: cannot register routes');
+  if (!app || typeof app.use !== "function") {
+    throw new Error("Invalid app instance: cannot register routes");
   }
 
-  if (typeof basePath !== 'string') {
-    throw new Error('Invalid path: basePath must be a string');
+  if (typeof basePath !== "string") {
+    throw new Error("Invalid path: basePath must be a string");
   }
 
   // If handlers is a single function, register it as GET
-  if (typeof handlers === 'function') {
-    app.get(basePath, handlers);
+  if (typeof handlers === "function" || Array.isArray(handlers)) {
+    const fns = normalizeHandlersToArray(handlers);
+    const wrapped = fns.map(wrapHandler);
+    app.get(basePath, ...wrapped);
     return;
   }
 
   if (!isPlainObject(handlers)) {
-    throw new Error('Handlers must be a function or a plain object');
+    throw new Error(
+      "Handlers must be a function, an array of functions, or a plain object"
+    );
   }
 
   // Iterate keys of handlers
@@ -41,14 +103,14 @@ function addRoute(app, basePath, handlers = {}) {
     const value = handlers[key];
 
     // Nested subpath (key starts with '/')
-    if (key.startsWith('/')) {
-      const subPath = basePath.endsWith('/')
-        ? basePath.slice(0, -1) + key
-        : basePath + key;
+    if (key.startsWith("/")) {
+      const subPath = joinPaths(basePath, key);
 
-      // If nested value is a function -> assume GET
-      if (typeof value === 'function') {
-        app.get(subPath, value);
+      // If nested value is a function or array -> assume GET
+      if (typeof value === "function" || Array.isArray(value)) {
+        const fns = normalizeHandlersToArray(value);
+        const wrapped = fns.map(wrapHandler);
+        app.get(subPath, ...wrapped);
         continue;
       }
 
@@ -58,12 +120,19 @@ function addRoute(app, basePath, handlers = {}) {
           const handlerFn = value[method];
           const m = method.toLowerCase();
           if (!supportedMethods.includes(m)) {
-            throw new Error(`Unsupported HTTP method "${method}" for route "${subPath}"`);
+            throw new Error(
+              `Unsupported HTTP method "${method}" for route "${subPath}"`
+            );
           }
-          if (typeof handlerFn !== 'function') {
-            throw new Error(`Handler for ${method} ${subPath} must be a function`);
+          // allow single function or array for handlerFn
+          if (typeof handlerFn !== "function" && !Array.isArray(handlerFn)) {
+            throw new Error(
+              `Handler for ${method} ${subPath} must be a function or array of functions`
+            );
           }
-          app[m](subPath, handlerFn);
+          const fns = normalizeHandlersToArray(handlerFn);
+          const wrapped = fns.map(wrapHandler);
+          app[m](subPath, ...wrapped);
         }
         continue;
       }
@@ -74,13 +143,19 @@ function addRoute(app, basePath, handlers = {}) {
     // Top-level method keys (like 'get', 'post', 'all', etc.)
     const m = key.toLowerCase();
     if (!supportedMethods.includes(m)) {
-      throw new Error(`Unsupported key "${key}" in handlers for path "${basePath}"`);
+      throw new Error(
+        `Unsupported key "${key}" in handlers for path "${basePath}"`
+      );
     }
     const fn = handlers[key];
-    if (typeof fn !== 'function') {
-      throw new Error(`Handler for ${m.toUpperCase()} ${basePath} must be a function`);
+    if (typeof fn !== "function" && !Array.isArray(fn)) {
+      throw new Error(
+        `Handler for ${m.toUpperCase()} ${basePath} must be a function or array of functions`
+      );
     }
-    app[m](basePath, fn);
+    const fns = normalizeHandlersToArray(fn);
+    const wrapped = fns.map(wrapHandler);
+    app[m](basePath, ...wrapped);
   }
 }
 

--- a/core/apiRoute.js
+++ b/core/apiRoute.js
@@ -1,10 +1,12 @@
 // core/apiRoute.js
 // Provide a simple helper to create RESTful resource routes.
 // Internally uses addRoute(app, basePath, handlers).
-// - resource: string like 'users' or '/users'
-// - handlers: function (assumed GET) or an object mapping methods and/or nested subpaths
+// Supports:
+// - handlers as a single function (assumed GET on collection)
+// - handlers as an object mapping methods and/or nested subpaths
+// - shorthand CRUD generation: pass { crud: true } or { crud: { list, create, show, update, remove } }
 
-const addRoute = require('./addRoute');
+const addRoute = require("./addRoute");
 
 /**
  * Normalize resource into a base path string.
@@ -12,43 +14,122 @@ const addRoute = require('./addRoute');
  * @returns {string} normalized path starting with '/'
  */
 function normalizeResource(resource) {
-  if (!resource) return '/';
-  if (typeof resource !== 'string') {
-    throw new Error('resource must be a string');
+  if (!resource) return "/";
+  if (typeof resource !== "string") {
+    throw new Error("resource must be a string");
   }
-  // trim trailing slash, ensure leading slash
   let r = resource.trim();
-  if (!r.startsWith('/')) r = '/' + r;
-  if (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
+  if (!r.startsWith("/")) r = "/" + r;
+  if (r.length > 1 && r.endsWith("/")) r = r.slice(0, -1);
   return r;
+}
+
+/**
+ * Create a stub handler returning 501 Not Implemented.
+ * @param {string} actionName
+ * @returns {Function} express handler
+ */
+function notImplementedHandler(actionName) {
+  return (req, res) => {
+    res
+      .status(501)
+      .json({ error: "Not Implemented", action: actionName || "unknown" });
+  };
+}
+
+/**
+ * Build handlers object for CRUD shorthand.
+ * Accepts optional mapping of handler functions.
+ *
+ * Expected keys supported in `h` (any subset):
+ *  - list / index        -> GET /resource
+ *  - create              -> POST /resource
+ *  - show / get / getById -> GET /resource/:id
+ *  - update              -> PUT /resource/:id
+ *  - remove / delete     -> DELETE /resource/:id
+ *
+ * @param {Object|boolean} h - handlers or true to auto-generate stubs
+ * @returns {Object} handlers object consumable by addRoute
+ */
+function buildCrudHandlers(h) {
+  const provided = h && typeof h === "object" ? h : {};
+  const pick = (keys) => {
+    for (const k of keys) {
+      if (typeof provided[k] === "function") return provided[k];
+    }
+    return null;
+  };
+
+  const listFn = pick(["list", "index"]);
+  const createFn = pick(["create"]);
+  const showFn = pick(["show", "get", "getById"]);
+  const updateFn = pick(["update"]);
+  const removeFn = pick(["remove", "delete"]);
+
+  const handlers = {};
+
+  // collection endpoints
+  handlers.get = listFn || notImplementedHandler("list");
+  handlers.post = createFn || notImplementedHandler("create");
+
+  // member endpoints under '/:id'
+  handlers["/:id"] = {
+    get: showFn || notImplementedHandler("show"),
+    put: updateFn || notImplementedHandler("update"),
+    delete: removeFn || notImplementedHandler("remove"),
+  };
+
+  return handlers;
 }
 
 /**
  * apiRoute(app, resource, handlers)
  * @param {Object} app - Express app (Kaelum app)
  * @param {string} resource - resource name or path (e.g. 'users' or '/users')
- * @param {Function|Object} handlers - function or object with methods and/or nested subpaths
+ * @param {Function|Object|boolean} handlers - function, object or shorthand (see README)
  */
 function apiRoute(app, resource, handlers = {}) {
-  if (!app || typeof app.use !== 'function') {
-    throw new Error('Invalid app instance: cannot register apiRoute');
+  if (!app || typeof app.use !== "function") {
+    throw new Error("Invalid app instance: cannot register apiRoute");
   }
 
   const basePath = normalizeResource(resource);
 
   // If handlers is a function, assume it's a GET on basePath
-  if (typeof handlers === 'function') {
+  if (typeof handlers === "function") {
     addRoute(app, basePath, handlers);
     return;
   }
 
-  // If handlers is not an object, throw
-  if (!handlers || typeof handlers !== 'object') {
-    throw new Error('Handlers must be a function or a plain object');
+  // If handlers is boolean true -> auto CRUD stubs
+  if (handlers === true) {
+    const crudHandlers = buildCrudHandlers(true);
+    addRoute(app, basePath, crudHandlers);
+    return;
   }
 
-  // Directly reuse addRoute: it supports method keys and nested '/:id' subpaths.
-  addRoute(app, basePath, handlers);
+  // If handlers is an object and has a 'crud' key, use it
+  if (
+    handlers &&
+    typeof handlers === "object" &&
+    handlers.hasOwnProperty("crud")
+  ) {
+    const crudSpec = handlers.crud;
+    const crudHandlers = buildCrudHandlers(crudSpec);
+    addRoute(app, basePath, crudHandlers);
+    return;
+  }
+
+  // If handlers is an object, assume it's the direct handlers map for addRoute
+  if (handlers && typeof handlers === "object") {
+    addRoute(app, basePath, handlers);
+    return;
+  }
+
+  // anything else is invalid
+  throw new Error(
+    "Handlers must be a function, an object, or boolean true for CRUD shorthand"
+  );
 }
 
 module.exports = apiRoute;

--- a/core/errorHandler.js
+++ b/core/errorHandler.js
@@ -1,49 +1,139 @@
 // core/errorHandler.js
 // Generic error handling middleware factory for Kaelum.
 //
+// Exports:
+//   - module.exports = errorHandlerFactory
+//   - module.exports.errorHandler = errorHandlerFactory
+//
 // Usage:
-//   const { errorHandler } = require('./core/errorHandler');
+//   const errorHandler = require('./core/errorHandler');
 //   app.use(errorHandler({ exposeStack: false }));
 //
-// The middleware responds with JSON:
-//   { error: { message: "...", code: "SOME_CODE" [, stack: "..." ] } }
-// - status is taken from err.status or err.statusCode or defaults to 500
-// - err.code is used if present; otherwise "INTERNAL_ERROR"
+// Options:
+//   - exposeStack: boolean (default false) -> include stack trace in JSON when true
+//   - logger: function(err, req, info?) optional -> custom logger
+//   - onError: function(err, req, res) optional -> hook called before sending response
+//
+// Response JSON shape:
+//   { error: { message, code, ...(stack) } }
+// Status chosen from err.status || err.statusCode || 500
 
-function errorHandler(options = {}) {
-  const { exposeStack = false } = options;
+/**
+ * @param {Object} options
+ * @param {boolean} [options.exposeStack=false] - include stack trace in responses
+ * @param {Function} [options.logger] - optional logger function: logger(err, req, info)
+ * @param {Function} [options.onError] - hook called before sending response: onError(err, req, res)
+ * @returns {Function} express error-handling middleware (err, req, res, next)
+ */
+function errorHandlerFactory(options = {}) {
+  const { exposeStack = false, logger = null, onError = null } = options || {};
 
-  return function (err, req, res, next) {
-    // If headers already sent, delegate to default Express handler
-    if (res.headersSent) {
-      return next(err);
-    }
-
-    const status = (err && (err.status || err.statusCode)) ? (err.status || err.statusCode) : 500;
-
-    const payload = {
-      error: {
-        message: (err && err.message) ? err.message : 'Internal Server Error',
-        code: (err && err.code) ? err.code : 'INTERNAL_ERROR'
-      }
-    };
-
-    if (exposeStack && err && err.stack) {
-      payload.error.stack = err.stack;
-    }
-
-    // Server-side logging: errors 5xx -> console.error, others -> console.warn
+  /**
+   * Default logger used when no custom logger is provided.
+   * @param {Error|any} err
+   * @param {Object} req
+   */
+  function defaultLog(err, req) {
+    const status =
+      err && (err.status || err.statusCode)
+        ? err.status || err.statusCode
+        : 500;
     if (status >= 500) {
-      // prefer stack if available
       if (err && err.stack) console.error(err.stack);
       else console.error(err);
     } else {
       if (err && err.message) console.warn(err.message);
       else console.warn(err);
     }
+  }
 
+  return function errorHandler(err, req, res, next) {
+    // If headers already sent, fall back to default express handler
+    if (res.headersSent) {
+      return next(err);
+    }
+
+    // normalize non-error values (e.g., throw "string")
+    const normalizedErr =
+      err instanceof Error
+        ? err
+        : new Error(typeof err === "string" ? err : "Unknown error");
+
+    // determine HTTP status
+    const status =
+      err && (err.status || err.statusCode)
+        ? err.status || err.statusCode
+        : 500;
+
+    // prepare payload
+    const payload = {
+      error: {
+        message:
+          (err && (err.message || err.msg)) ||
+          normalizedErr.message ||
+          "Internal Server Error",
+        code: err && err.code ? err.code : "INTERNAL_ERROR",
+      },
+    };
+
+    if (exposeStack && normalizedErr && normalizedErr.stack) {
+      payload.error.stack = normalizedErr.stack;
+    }
+
+    // logging: prefer custom logger if provided
+    try {
+      if (typeof logger === "function") {
+        // allow custom logger to receive (err, req, { status })
+        logger(normalizedErr, req, { status });
+      } else {
+        defaultLog(normalizedErr, req);
+      }
+    } catch (logErr) {
+      // don't crash if logger fails
+      console.error("Kaelum errorHandler: logger threw an error", logErr);
+    }
+
+    // onError hook (e.g., report to external service)
+    try {
+      if (typeof onError === "function") {
+        try {
+          onError(normalizedErr, req, res);
+        } catch (hookErr) {
+          // don't block response if hook fails
+          console.error("Kaelum errorHandler: onError hook threw", hookErr);
+        }
+      }
+    } catch (_) {
+      // ignore
+    }
+
+    // Respond according to Accept header: JSON preferred, fallback to text/html
+    if (req && req.accepts && req.accepts("html") && !req.accepts("json")) {
+      // simple HTML response for browsers preferring HTML
+      const title = `Error ${status}`;
+      const body = `
+        <!doctype html>
+        <html>
+          <head><meta charset="utf-8"/><title>${title}</title></head>
+          <body>
+            <h1>${title}</h1>
+            <p>${payload.error.message}</p>
+            ${
+              exposeStack && payload.error.stack
+                ? `<pre>${payload.error.stack}</pre>`
+                : ""
+            }
+          </body>
+        </html>`;
+      res.status(status).type("html").send(body);
+      return;
+    }
+
+    // default: JSON response
     res.status(status).json(payload);
   };
 }
 
-module.exports = { errorHandler };
+// Export both default and named to keep compatibility with different import styles
+module.exports = errorHandlerFactory;
+module.exports.errorHandler = errorHandlerFactory;

--- a/core/healthCheck.js
+++ b/core/healthCheck.js
@@ -1,52 +1,204 @@
 // core/healthCheck.js
-// Simple health-check route helper for Kaelum.
-// Usage: registerHealth(app, '/health')
+// Kaelum - health check helper
+//
+// Exports a factory function to register a health (liveness/readiness) endpoint.
+//
+// Usage examples:
+//   const registerHealth = require('./core/healthCheck');
+//   // simple
+//   registerHealth(app);
+//   // with options
+//   registerHealth(app, {
+//     path: '/health',
+//     readinessCheck: async () => {
+//       // custom checks (e.g. DB ping). Return { ok: true, details: { ... } } or { ok: false, details: {...} }
+//       const ok = await db.ping();
+//       return { ok, details: { db: ok } };
+//     },
+//     include: { uptime: true, pid: true, env: true, timestamp: true },
+//     replace: true
+//   });
+
+const DEFAULT_PATH = "/health";
 
 /**
- * Register a health-check endpoint.
- * @param {Object} app - Express/Kaelum app instance
- * @param {string} routePath - route path (default '/health')
+ * @typedef {Object} HealthOptions
+ * @property {string} [path] - Endpoint path (default '/health')
+ * @property {string} [method] - HTTP method for health endpoint (default 'get')
+ * @property {boolean} [replace] - If true and a previous Kaelum-installed endpoint exists, replace it (default false)
+ * @property {Function} [readinessCheck] - Optional async function that returns { ok: boolean, details?: Object }
+ * @property {Object} [include] - Which fields to include in payload. Defaults to all true.
+ * @property {boolean} [include.uptime]
+ * @property {boolean} [include.pid]
+ * @property {boolean} [include.env]
+ * @property {boolean} [include.timestamp]
+ * @property {boolean} [include.metrics] - reserved for future metrics (default false)
  */
-function registerHealth(app, routePath = "/health") {
+
+/**
+ * Check if the same route path+method already exists in the app router.
+ * Only inspects Kaelum-installed layers conservatively.
+ * @param {Object} app - express app
+ * @param {string} path
+ * @param {string} method
+ * @returns {boolean}
+ */
+function routeExists(app, path, method) {
+  try {
+    if (!app || !app._router || !Array.isArray(app._router.stack)) return false;
+    return app._router.stack.some((layer) => {
+      if (!layer || !layer.route) return false;
+      if (layer.route.path !== path) return false;
+      return (
+        !!layer.route.methods && !!layer.route.methods[method.toLowerCase()]
+      );
+    });
+  } catch (e) {
+    // if internal inspection fails, be conservative and return false
+    return false;
+  }
+}
+
+/**
+ * Register a health check endpoint on the provided Express/Kaelum app.
+ * @param {Object} app - Express/Kaelum app instance
+ * @param {HealthOptions|string} [opts] - options or a string path
+ * @returns {Function} the handler function created (useful for tests)
+ */
+function registerHealth(app, opts = {}) {
   if (!app || typeof app.get !== "function") {
     throw new Error("Invalid app instance: cannot register health check");
   }
 
-  const p =
-    typeof routePath === "string"
-      ? routePath.startsWith("/")
-        ? routePath
-        : "/" + routePath
-      : "/health";
+  // allow shorthand: passing a string path
+  const options =
+    typeof opts === "string"
+      ? { path: opts }
+      : Object.assign(
+          {
+            path: DEFAULT_PATH,
+            method: "get",
+            replace: false,
+            readinessCheck: null,
+            include: {
+              uptime: true,
+              pid: true,
+              env: true,
+              timestamp: true,
+              metrics: false,
+            },
+          },
+          opts || {}
+        );
 
-  // Remove any previous handler for the same path if present to avoid duplication.
-  // We'll be conservative and not remove other handlers globally.
-  try {
-    // If there is already an identical layer, skip adding another.
-    const existing =
-      app._router && Array.isArray(app._router.stack)
-        ? app._router.stack.find(
-            (layer) =>
-              layer.route &&
-              layer.route.path === p &&
-              layer.route.methods &&
-              layer.route.methods.get
-          )
-        : null;
-    if (existing) return;
-  } catch (e) {
-    // ignore internal inspection failures and proceed to register
+  // normalize path and method
+  let p =
+    options.path && typeof options.path === "string"
+      ? options.path
+      : DEFAULT_PATH;
+  if (!p.startsWith("/")) p = "/" + p;
+  const method = (options.method || "get").toLowerCase();
+
+  // if route exists and replace is false -> skip registration
+  if (routeExists(app, p, method) && !options.replace) {
+    return null;
   }
 
-  app.get(p, (req, res) => {
-    res.json({
+  // if replace requested, attempt to remove prior Kaelum-installed handler
+  if (options.replace) {
+    try {
+      // remove layers that match exactly the route path and method
+      if (app._router && Array.isArray(app._router.stack)) {
+        app._router.stack = app._router.stack.filter((layer) => {
+          if (!layer || !layer.route) return true; // keep non-route layers
+          if (layer.route.path !== p) return true; // keep other routes
+          // keep only layers that do not match the method we want to replace
+          return !layer.route.methods || !layer.route.methods[method];
+        });
+      }
+    } catch (e) {
+      // ignore removal errors - continue to register anyway
+    }
+  } else {
+    // if route exists and replace === false we already returned above
+  }
+
+  /**
+   * The handler performs an optional readinessCheck. If readinessCheck returns
+   * { ok: false } then status 503 is sent, otherwise 200.
+   * readinessCheck may be synchronous or asynchronous.
+   */
+  const handler = async (req, res) => {
+    // default payload base
+    const payload = {
       status: "OK",
-      uptime: process.uptime(),
-      timestamp: Date.now(),
-      pid: process.pid,
-      env: process.env.NODE_ENV || "development",
-    });
-  });
+    };
+
+    // include optional fields
+    const inc = options.include || {};
+    if (inc.uptime) payload.uptime = process.uptime();
+    if (inc.pid) payload.pid = process.pid;
+    if (inc.env) payload.env = process.env.NODE_ENV || "development";
+    if (inc.timestamp) payload.timestamp = Date.now();
+
+    // readiness check (optional)
+    if (typeof options.readinessCheck === "function") {
+      try {
+        const result = await Promise.resolve(options.readinessCheck(req));
+        // result expected to be { ok: boolean, details?: object } or boolean
+        let ok = true;
+        let details = undefined;
+        if (typeof result === "boolean") {
+          ok = result;
+        } else if (result && typeof result === "object") {
+          ok = !!result.ok;
+          details = result.details;
+        } else {
+          // unrecognized result -> consider as ok
+          ok = true;
+        }
+
+        if (!ok) {
+          payload.status = "FAIL";
+          if (details) payload.details = details;
+          return res.status(503).json(payload);
+        }
+      } catch (err) {
+        // readiness check threw -> respond 503 with error info (don't expose stack)
+        payload.status = "FAIL";
+        payload.details = {
+          message: err && err.message ? err.message : "readiness check error",
+        };
+        return res.status(503).json(payload);
+      }
+    }
+
+    // success
+    return res.status(200).json(payload);
+  };
+
+  // register route on app
+  try {
+    // attach a marker so we can detect Kaelum-installed static handlers if needed
+    app[method](p, handler);
+  } catch (e) {
+    throw new Error(
+      `Failed to register health route ${method.toUpperCase()} ${p}: ${
+        e.message
+      }`
+    );
+  }
+
+  // store reference in locals for future inspection/removal
+  try {
+    app.locals = app.locals || {};
+    app.locals._kaelum_health = app.locals._kaelum_health || [];
+    app.locals._kaelum_health.push({ path: p, method, handler });
+  } catch (_) {
+    // ignore locals storage errors
+  }
+
+  return handler;
 }
 
 module.exports = registerHealth;

--- a/core/redirect.js
+++ b/core/redirect.js
@@ -1,41 +1,177 @@
 // core/redirect.js
-// Helper to register simple redirect routes in Kaelum.
-// Usage: redirect(app, '/old', '/new', 302)
-// Returns the app for chaining.
+// Kaelum - redirect helper
+//
+// This module provides a flexible helper to register one or many redirect routes
+// in a Kaelum/Express app. It stores references to Kaelum-installed redirect
+// handlers so future calls can remove only the handlers Kaelum created (safe removal).
+//
+// Usage examples:
+//   const redirect = require('./core/redirect');
+//   // simple single redirect
+//   redirect(app, '/old', '/new', 301);
+//
+//   // as map (object)
+//   redirect(app, { '/old': '/new', '/a': '/b' });
+//
+//   // as array of objects
+//   redirect(app, [
+//     { from: '/x', to: '/y', status: 302 },
+//     { from: '/a', to: '/b' }
+//   ]);
+//
+//   // returns array of registered entries or null if nothing registered.
 
-function redirect(app, fromPath, toPath, status = 302) {
+function normalizePath(p) {
+  if (!p) return "/";
+  if (typeof p !== "string") throw new Error("path must be a string");
+  return p.startsWith("/") ? p : "/" + p;
+}
+
+function normalizeStatus(s) {
+  const n = Number(s);
+  if (!Number.isFinite(n)) return 302;
+  // limit to common redirect codes 300-399
+  if (n < 300 || n >= 400) return 302;
+  return Math.floor(n);
+}
+
+function ensureLocals(app) {
+  app.locals = app.locals || {};
+  app.locals._kaelum_redirects = app.locals._kaelum_redirects || [];
+}
+
+/**
+ * Safely remove a previously registered Kaelum redirect handler for a path.
+ * Only removes handlers that we registered (tracked in app.locals._kaelum_redirects).
+ * @param {Object} app
+ * @param {string} path
+ */
+function removeKaelumRedirectsForPath(app, path) {
+  if (!app || !app._router || !Array.isArray(app._router.stack)) return;
+  if (!app.locals || !Array.isArray(app.locals._kaelum_redirects)) return;
+
+  // find tracked entries for this path
+  const tracked = app.locals._kaelum_redirects.filter((r) => r.path === path);
+  if (tracked.length === 0) return;
+
+  // remove router layers whose handler matches tracked.handler
+  app._router.stack = app._router.stack.filter((layer) => {
+    // keep everything that is not a route
+    if (!layer || !layer.route) return true;
+    if (layer.route.path !== path) return true;
+    // check if route stack contains a tracked handler
+    const handlers = layer.route.stack || [];
+    for (const entry of tracked) {
+      for (const h of handlers) {
+        if (h && h.handle === entry.handler) {
+          // drop this layer (do not keep)
+          return false;
+        }
+      }
+    }
+    // if none of the tracked handlers matched, keep the layer
+    return true;
+  });
+
+  // remove tracked entries for that path from locals
+  app.locals._kaelum_redirects = app.locals._kaelum_redirects.filter(
+    (r) => r.path !== path
+  );
+}
+
+/**
+ * Register a single redirect handler and track it in app.locals.
+ * @param {Object} app
+ * @param {string} from
+ * @param {string} to
+ * @param {number} status
+ * @returns {{ path: string, to: string, status: number }}
+ */
+function registerSingleRedirect(app, from, to, status) {
+  const path = normalizePath(from);
+  const target = to;
+  const code = normalizeStatus(status);
+
+  // create handler and register GET route
+  const handler = function (req, res) {
+    res.redirect(code, target);
+  };
+
+  // add to express
+  app.get(path, handler);
+
+  // track it
+  ensureLocals(app);
+  app.locals._kaelum_redirects.push({
+    path,
+    handler,
+    to: target,
+    status: code,
+  });
+
+  return { path, to: target, status: code };
+}
+
+/**
+ * Main redirect export.
+ * Accepts:
+ *  - (app, from, to, status?)
+ *  - (app, mapObject) where mapObject is { from: to, ... }
+ *  - (app, array) where array contains { from, to, status? } entries
+ *
+ * @param {Object} app - Express/Kaelum app
+ * @param {string|Object|Array} fromOrMap - path string or map/object or array of mappings
+ * @param {string|number} [toOrStatus] - when calling with (app, from, to, status) this is the "to" parameter
+ * @param {number} [maybeStatus] - optional status when calling the 4-arg form
+ * @returns {Array|null} list of registered redirect entries or null if none
+ */
+function redirect(app, fromOrMap, toOrStatus, maybeStatus) {
   if (!app || typeof app.get !== "function") {
     throw new Error("Invalid app instance: cannot register redirect");
   }
-  if (typeof fromPath !== "string" || typeof toPath !== "string") {
-    throw new Error("redirect: fromPath and toPath must be strings");
+
+  ensureLocals(app);
+
+  const registered = [];
+
+  // Helper: register one mapping (and remove previous Kaelum mapping for that path)
+  function applyMapping(from, to, status) {
+    const path = normalizePath(from);
+    // remove previously Kaelum-registered redirects for same path (safe removal)
+    removeKaelumRedirectsForPath(app, path);
+    // register and track
+    const res = registerSingleRedirect(app, path, to, status);
+    registered.push(res);
   }
 
-  const from = fromPath.startsWith("/") ? fromPath : "/" + fromPath;
-
-  // Avoid duplicate registration: remove existing route with same path if present
-  try {
-    if (app._router && Array.isArray(app._router.stack)) {
-      app._router.stack = app._router.stack.filter((layer) => {
-        // keep layers that are not the same GET route
-        if (!layer.route) return true;
-        if (layer.route && layer.route.path === from) {
-          // remove old route for same path (prevents duplicates)
-          return false;
-        }
-        return true;
-      });
+  // Determine input shape
+  if (typeof fromOrMap === "string") {
+    // form: redirect(app, '/old', '/new', 302)
+    const from = fromOrMap;
+    const to = typeof toOrStatus === "string" ? toOrStatus : "/";
+    const status =
+      typeof maybeStatus !== "undefined" ? maybeStatus : toOrStatus;
+    applyMapping(from, to, status);
+  } else if (Array.isArray(fromOrMap)) {
+    // array of objects: [{ from, to, status }]
+    for (const item of fromOrMap) {
+      if (!item) continue;
+      const from = item.from || item.path || null;
+      const to = item.to || item.target || null;
+      const status = item.status || item.code || 302;
+      if (!from || !to) continue;
+      applyMapping(from, to, status);
     }
-  } catch (e) {
-    // If internal inspection fails, continue and add the new handler anyway
+  } else if (fromOrMap && typeof fromOrMap === "object") {
+    // object map: { '/old': '/new', 'a': 'b' }
+    for (const k of Object.keys(fromOrMap)) {
+      applyMapping(k, fromOrMap[k], 302);
+    }
+  } else {
+    throw new Error("Invalid arguments for redirect");
   }
 
-  // Register a GET route that redirects
-  app.get(from, (req, res) => {
-    res.redirect(status, toPath);
-  });
-
-  return app;
+  return registered.length ? registered : null;
 }
 
 module.exports = redirect;

--- a/core/setConfig.js
+++ b/core/setConfig.js
@@ -1,7 +1,8 @@
 // core/setConfig.js
 // Kaelum centralized configuration helper.
 // - Supports toggling CORS, Helmet, static folder, Morgan logs, bodyParser, and port.
-// - Persists merged config to app locals (app.set("kaelum:config", ...)).
+// - Persists merged config to app.locals and app.set("kaelum:config", ...).
+// - Idempotent: won't add the same Kaelum-installed middleware twice and can remove them.
 
 const path = require("path");
 
@@ -17,17 +18,19 @@ function tryRequire(name) {
  * Merge new options into existing stored config
  * @param {Object} app
  * @param {Object} options
+ * @returns {Object} merged config
  */
 function persistConfig(app, options = {}) {
   const prev = app.locals.kaelumConfig || {};
   const merged = Object.assign({}, prev, options);
   app.locals.kaelumConfig = merged;
-  app.set("kaelum:config", merged);
+  if (typeof app.set === "function") app.set("kaelum:config", merged);
   return merged;
 }
 
 /**
  * Remove a middleware function reference from express stack
+ * Safely filters layers whose handle === fn
  * @param {Object} app
  * @param {Function} fn
  */
@@ -37,111 +40,158 @@ function removeMiddlewareByFn(app, fn) {
 }
 
 /**
- * Remove static middleware previously installed by Kaelum (if any)
+ * Install middleware (store reference in app.locals under key)
+ * If there is a previous middleware stored at that key, remove it first.
  * @param {Object} app
+ * @param {string} localKey
+ * @param {Function} middlewareFn
  */
-function removeKaelumStatic(app) {
-  const prev = app.locals && app.locals._kaelum_static;
+function installMiddleware(app, localKey, middlewareFn) {
+  if (!app) return;
+  // remove previous if exists
+  const prev = app.locals && app.locals[localKey];
   if (prev) {
-    removeMiddlewareByFn(app, prev);
-    app.locals._kaelum_static = null;
+    try {
+      removeMiddlewareByFn(app, prev);
+    } catch (e) {
+      // ignore removal errors
+    }
+  }
+  app.locals[localKey] = middlewareFn;
+  app.use(middlewareFn);
+}
+
+/**
+ * Remove middleware stored in app.locals under localKey
+ * @param {Object} app
+ * @param {string} localKey
+ */
+function removeLocalMiddleware(app, localKey) {
+  if (!app || !app.locals) return;
+  const prev = app.locals[localKey];
+  if (prev) {
+    try {
+      removeMiddlewareByFn(app, prev);
+    } catch (e) {
+      // ignore
+    }
+    app.locals[localKey] = null;
   }
 }
 
 /**
- * Remove body parsers previously installed by Kaelum
+ * Ensure body parsers exist (and store references)
+ * @param {Object} app
+ */
+function ensureBodyParsers(app) {
+  if (!app.locals) app.locals = {};
+  if (
+    !Array.isArray(app.locals._kaelum_bodyparsers) ||
+    app.locals._kaelum_bodyparsers.length === 0
+  ) {
+    const expressPkg = tryRequire("express") || require("express");
+    const jsonParser = expressPkg.json();
+    const urlencodedParser = expressPkg.urlencoded({ extended: true });
+    app.locals._kaelum_bodyparsers = [jsonParser, urlencodedParser];
+    app.use(jsonParser);
+    app.use(urlencodedParser);
+  }
+}
+
+/**
+ * Remove Kaelum-installed body parsers
  * @param {Object} app
  */
 function removeKaelumBodyParsers(app) {
-  const arr = app.locals && app.locals._kaelum_bodyparsers;
+  if (!app || !app.locals) return;
+  const arr = app.locals._kaelum_bodyparsers;
   if (Array.isArray(arr)) {
-    arr.forEach((fn) => removeMiddlewareByFn(app, fn));
-    app.locals._kaelum_bodyparsers = [];
+    arr.forEach((fn) => {
+      try {
+        removeMiddlewareByFn(app, fn);
+      } catch (e) {
+        // ignore
+      }
+    });
   }
-}
-
-/**
- * Remove morgan logger if previously set
- * @param {Object} app
- */
-function removeKaelumLogger(app) {
-  const prev = app.locals && app.locals._kaelum_logger;
-  if (prev) {
-    removeMiddlewareByFn(app, prev);
-    app.locals._kaelum_logger = null;
-  }
+  app.locals._kaelum_bodyparsers = [];
 }
 
 /**
  * Apply configuration options to the app
  * @param {Object} app - express app instance
  * @param {Object} options - supported keys: cors, helmet, static, logs, port, bodyParser
+ * @returns {Object} merged config
  */
 function setConfig(app, options = {}) {
   if (!app) throw new Error("setConfig requires an app instance");
 
-  // persist/merge config
+  // ensure locals exist
+  app.locals = app.locals || {};
+
+  // merge/persist config first
   const cfg = persistConfig(app, options);
 
   // --- CORS ---
   if (options.hasOwnProperty("cors")) {
+    // If user wants to enable CORS
     if (options.cors) {
-      const cors = tryRequire("cors");
-      const corsOpts = options.cors === true ? {} : options.cors;
-      if (!cors) {
+      const corsPkg = tryRequire("cors");
+      if (!corsPkg) {
         console.warn(
           "Kaelum: cors package not installed. Skipping CORS setup."
         );
       } else {
-        // remove previous cors if exists (we can't easily find it by fn, so we rely on setConfig being idempotent)
-        // For safety, do not try to remove every cors instance — assume user calls setConfig once
-        app.use(cors(corsOpts));
+        // create middleware from provided options if object, or empty opts
+        const corsOpts = options.cors === true ? {} : options.cors;
+        const middleware = corsPkg(corsOpts);
+        installMiddleware(app, "_kaelum_cors", middleware);
         console.log("🛡️  CORS activated.");
       }
     } else {
-      // If false, we can't reliably remove community middleware, but attempt to remove Kaelum-installed ones.
-      // No-op if not installed.
-      // (Note: if user installed cors manually, we won't remove it.)
+      // disable Kaelum-installed CORS if present
+      removeLocalMiddleware(app, "_kaelum_cors");
+      console.log("🛡️  CORS disabled (Kaelum-installed instance removed).");
     }
   }
 
   // --- Helmet ---
   if (options.hasOwnProperty("helmet")) {
     if (options.helmet) {
-      const helmet = tryRequire("helmet");
-      const helmetOpts = options.helmet === true ? {} : options.helmet;
-      if (!helmet) {
+      const helmetPkg = tryRequire("helmet");
+      if (!helmetPkg) {
         console.warn(
           "Kaelum: helmet package not installed. Skipping Helmet setup."
         );
       } else {
-        app.use(helmet(helmetOpts));
+        const helmetOpts = options.helmet === true ? {} : options.helmet;
+        const middleware = helmetPkg(helmetOpts);
+        installMiddleware(app, "_kaelum_helmet", middleware);
         console.log("🛡️  Helmet activated.");
       }
     } else {
-      // No-op for manual removals currently.
+      removeLocalMiddleware(app, "_kaelum_helmet");
+      console.log("🛡️  Helmet disabled (Kaelum-installed instance removed).");
     }
   }
 
   // --- Static folder handling ---
   if (options.hasOwnProperty("static")) {
     // remove previous Kaelum static
-    removeKaelumStatic(app);
+    removeLocalMiddleware(app, "_kaelum_static");
 
     if (options.static) {
-      const expressStatic =
-        tryRequire("express").static || require("express").static;
-      // resolve to absolute path relative to project root if necessary
+      const expressStatic = (tryRequire("express") || require("express"))
+        .static;
       const dir =
         typeof options.static === "string"
           ? path.resolve(process.cwd(), options.static)
           : path.join(process.cwd(), "public");
       const staticFn = expressStatic(dir);
-      app.locals._kaelum_static = staticFn;
-      app.use(staticFn);
+      installMiddleware(app, "_kaelum_static", staticFn);
       console.log(`📁 Static files served from ${dir}`);
     } else {
-      // static === false -> nothing to add (static removed)
+      // static === false -> nothing to add, just removed above
       console.log("📁 Static serving disabled.");
     }
   }
@@ -151,39 +201,31 @@ function setConfig(app, options = {}) {
     if (options.bodyParser === false) {
       // remove Kaelum-installed body parsers
       removeKaelumBodyParsers(app);
-      console.log("📦 Body parsers disabled.");
+      console.log("📦 Body parsers disabled (Kaelum-installed removed).");
     } else {
-      // ensure body parsers are installed (if not present)
-      if (
-        !app.locals._kaelum_bodyparsers ||
-        app.locals._kaelum_bodyparsers.length === 0
-      ) {
-        const jsonParser = tryRequire("express").json();
-        const urlencodedParser = tryRequire("express").urlencoded({
-          extended: true,
-        });
-        app.locals._kaelum_bodyparsers = [jsonParser, urlencodedParser];
-        app.use(jsonParser);
-        app.use(urlencodedParser);
-        console.log("📦 Body parsers enabled (JSON + URL-encoded).");
-      }
+      // enable if not present
+      ensureBodyParsers(app);
+      console.log("📦 Body parsers enabled (JSON + URL-encoded).");
     }
+  } else {
+    // no explicit bodyParser option -> ensure default enabled if not present
+    ensureBodyParsers(app);
   }
 
   // --- Logs (morgan) ---
   if (options.hasOwnProperty("logs")) {
     // remove previous logger first
-    removeKaelumLogger(app);
+    removeLocalMiddleware(app, "_kaelum_logger");
 
     if (options.logs) {
       const morgan = tryRequire("morgan");
       if (!morgan) {
         console.warn("Kaelum: morgan package not installed. Skipping logs.");
       } else {
-        // simple dev format by default; could be configured
-        const logger = morgan("dev");
-        app.locals._kaelum_logger = logger;
-        app.use(logger);
+        // allow user to pass string format or object; default to 'dev'
+        const format = options.logs === true ? "dev" : options.logs || "dev";
+        const logger = morgan(format);
+        installMiddleware(app, "_kaelum_logger", logger);
         console.log("📊 Request logging enabled (morgan).");
       }
     } else {
@@ -199,13 +241,14 @@ function setConfig(app, options = {}) {
       const merged = Object.assign({}, app.locals.kaelumConfig);
       delete merged.port;
       app.locals.kaelumConfig = merged;
-      app.set("kaelum:config", merged);
+      if (typeof app.set === "function") app.set("kaelum:config", merged);
       console.log("🔌 Port preference cleared from Kaelum config.");
     } else if (typeof p === "number" || typeof p === "string") {
       // persist port as number if possible
       const asNum = Number(p);
       app.locals.kaelumConfig.port = Number.isNaN(asNum) ? p : asNum;
-      app.set("kaelum:config", app.locals.kaelumConfig);
+      if (typeof app.set === "function")
+        app.set("kaelum:config", app.locals.kaelumConfig);
       console.log(
         `🔌 Port set to ${app.locals.kaelumConfig.port} in Kaelum config.`
       );

--- a/core/setMiddleware.js
+++ b/core/setMiddleware.js
@@ -1,66 +1,190 @@
 // core/setMiddleware.js
-// Register middleware(s) on the Express app
-// Usage:
-// - setMiddleware(app, middlewareFn)
-// - setMiddleware(app, [mw1, mw2])
-// - setMiddleware(app, '/path', middlewareFn) -> mounts on a path
+// Kaelum middleware manager
+//
+// - supports:
+//   setMiddleware(app, middlewareFn)
+//   setMiddleware(app, [mw1, mw2])
+//   setMiddleware(app, '/path', middlewareFn)
+// - tracks Kaelum-installed middlewares in app.locals._kaelum_middlewares
+// - provides removal helper: setMiddleware.remove(app, [path])
+//
+// Comments / JSDoc in English as requested.
 
+/**
+ * Check if value is a function
+ * @param {*} v
+ * @returns {boolean}
+ */
 function isFunction(v) {
-  return typeof v === 'function';
+  return typeof v === "function";
 }
 
-function setMiddleware(app, a, b) {
-  // Signature variants:
-  // setMiddleware(app, middleware)
-  // setMiddleware(app, [middleware1, middleware2])
-  // setMiddleware(app, path, middleware)
+/**
+ * Ensure app.locals containers exist
+ * @param {Object} app
+ */
+function ensureLocals(app) {
+  app.locals = app.locals || {};
+  if (!Array.isArray(app.locals._kaelum_middlewares)) {
+    app.locals._kaelum_middlewares = [];
+  }
+}
 
-  if (!app || typeof app.use !== 'function') {
-    throw new Error('Invalid app instance: cannot apply middleware');
+/**
+ * Internal helper: register one middleware (with optional path) and track it.
+ * @param {Object} app
+ * @param {string|null} path
+ * @param {Function} handler
+ * @returns {{ path: string|null, handler: Function }}
+ */
+function registerMiddleware(app, path, handler) {
+  if (path) {
+    app.use(path, handler);
+  } else {
+    app.use(handler);
   }
 
-  // two args -> could be (app, middlewareOrArray) OR (app, path)
+  ensureLocals(app);
+  const entry = { path: path || null, handler };
+  app.locals._kaelum_middlewares.push(entry);
+  return entry;
+}
+
+/**
+ * Remove Kaelum-installed middlewares for a given path (or all if path==null).
+ * Only removes handlers that were registered by Kaelum (tracked in app.locals._kaelum_middlewares).
+ * @param {Object} app
+ * @param {string|null} path
+ */
+function removeKaelumMiddlewaresForPath(app, path = null) {
+  if (!app || !app._router || !Array.isArray(app._router.stack)) return;
+
+  ensureLocals(app);
+
+  // Filter tracked entries for removal
+  const toRemove = app.locals._kaelum_middlewares.filter((e) => {
+    if (path === null) return true;
+    return e.path === path;
+  });
+
+  if (toRemove.length === 0) return;
+
+  // Remove layers whose handler matches any tracked handler for the path
+  app._router.stack = app._router.stack.filter((layer) => {
+    // keep non-route layers and those that aren't middleware we tracked
+    if (!layer || !layer.handle) return true;
+    // For mounted middleware, express keeps the handler directly as layer.handle
+    for (const entry of toRemove) {
+      if (layer.handle === entry.handler) {
+        return false; // drop this layer
+      }
+    }
+    return true;
+  });
+
+  // remove entries from tracked list
+  app.locals._kaelum_middlewares = app.locals._kaelum_middlewares.filter(
+    (e) => {
+      if (path === null) return false; // remove all
+      return e.path !== path;
+    }
+  );
+}
+
+/**
+ * setMiddleware - register middleware(s) and track them as Kaelum-installed.
+ *
+ * Signatures:
+ *  - setMiddleware(app, middleware)
+ *  - setMiddleware(app, [mw1, mw2])
+ *  - setMiddleware(app, path, middleware)
+ *
+ * Returns array of registered entries: [{ path, handler }, ...]
+ *
+ * @param {Object} app - Express app
+ * @param {string|Function|Array} a - path or middleware or array
+ * @param {Function|Array} [b] - middleware or array when a is path
+ */
+function setMiddleware(app, a, b) {
+  if (!app || typeof app.use !== "function") {
+    throw new Error("Invalid app instance: cannot apply middleware");
+  }
+
+  const registered = [];
+
+  // two args: (app, middlewareOrArray)
   if (arguments.length === 2) {
     const middleware = a;
-    if (typeof middleware === 'string') {
-      throw new Error('Missing middleware function for given path');
-    }
+
     if (Array.isArray(middleware)) {
-      middleware.forEach((mw) => {
-        if (!isFunction(mw)) throw new Error('All middlewares in array must be functions');
-        app.use(mw);
-      });
-      return;
+      for (const mw of middleware) {
+        if (!isFunction(mw)) {
+          throw new Error("All middlewares in array must be functions");
+        }
+        registered.push(registerMiddleware(app, null, mw));
+      }
+      return registered;
     }
+
     if (!isFunction(middleware)) {
-      throw new Error('Middleware must be a function or an array of functions');
+      throw new Error("Middleware must be a function or an array of functions");
     }
-    app.use(middleware);
-    return;
+
+    registered.push(registerMiddleware(app, null, middleware));
+    return registered;
   }
 
-  // three args -> (app, path, middleware)
+  // three args: (app, path, middleware)
   if (arguments.length === 3) {
     const path = a;
     const middleware = b;
-    if (typeof path !== 'string') {
-      throw new Error('Path must be a string when using three-argument setMiddleware');
+
+    if (typeof path !== "string") {
+      throw new Error(
+        "Path must be a string when using three-argument setMiddleware"
+      );
     }
+
     if (Array.isArray(middleware)) {
-      middleware.forEach((mw) => {
-        if (!isFunction(mw)) throw new Error('All middlewares in array must be functions');
-        app.use(path, mw);
-      });
-      return;
+      for (const mw of middleware) {
+        if (!isFunction(mw)) {
+          throw new Error("All middlewares in array must be functions");
+        }
+        registered.push(registerMiddleware(app, path, mw));
+      }
+      return registered;
     }
+
     if (!isFunction(middleware)) {
-      throw new Error('Middleware must be a function or an array of functions');
+      throw new Error("Middleware must be a function or an array of functions");
     }
-    app.use(path, middleware);
-    return;
+
+    registered.push(registerMiddleware(app, path, middleware));
+    return registered;
   }
 
-  throw new Error('Invalid number of arguments for setMiddleware');
+  throw new Error("Invalid number of arguments for setMiddleware");
 }
+
+/**
+ * Remove tracked Kaelum middlewares.
+ * - setMiddleware.remove(app) => removes all Kaelum-installed middlewares
+ * - setMiddleware.remove(app, path) => removes Kaelum-installed middlewares mounted at that path
+ *
+ * @param {Object} app
+ * @param {string} [path]
+ */
+setMiddleware.remove = function (app, path) {
+  if (!app) return;
+  if (typeof path !== "undefined" && typeof path !== "string") {
+    throw new Error(
+      "Path must be a string when provided to setMiddleware.remove"
+    );
+  }
+  removeKaelumMiddlewaresForPath(app, typeof path === "string" ? path : null);
+  return app.locals && app.locals._kaelum_middlewares
+    ? app.locals._kaelum_middlewares
+    : [];
+};
 
 module.exports = setMiddleware;

--- a/core/start.js
+++ b/core/start.js
@@ -1,26 +1,112 @@
 // core/start.js
 // Start helper for Kaelum: uses port passed or reads from Kaelum config, or falls back to 3000.
+// - Validates port number
+// - Respects persisted config (app.get("kaelum:config") or app.locals.kaelumConfig)
+// - If a server is already running, returns the existing server (no double-listen)
+// - Stores the server instance in app.locals._kaelum_server
+// - Attaches basic error logging for startup errors
 
+/**
+ * Normalize and validate a port-like value.
+ * Accepts numbers or numeric strings. Returns integer port.
+ * Throws on invalid values.
+ * @param {number|string|undefined|null} val
+ * @returns {number|undefined}
+ */
+function normalizePort(val) {
+  if (typeof val === "undefined" || val === null || val === "")
+    return undefined;
+  const p = typeof val === "number" ? val : parseInt(String(val), 10);
+  if (Number.isNaN(p) || !Number.isInteger(p)) {
+    throw new Error(`Invalid port value: ${val}`);
+  }
+  if (p < 1 || p > 65535) {
+    throw new Error(`Port out of range: ${p} (must be 1-65535)`);
+  }
+  return p;
+}
+
+/**
+ * Start the Express app listening on the given port (or config / default).
+ * Returns the Node HTTP server instance.
+ *
+ * @param {Object} app - Express app instance
+ * @param {number|string} [port] - optional port override
+ * @param {Function} [cb] - optional callback invoked when server starts (signature: () => void)
+ * @returns {import('http').Server} server instance
+ */
 function start(app, port, cb) {
   if (!app) throw new Error("start requires an app instance");
 
-  // If port omitted, try to read from Kaelum config
-  let usePort = port;
-  if (typeof usePort === "undefined" || usePort === null) {
-    const cfg = app.get("kaelum:config") || app.locals.kaelumConfig || {};
-    if (cfg && cfg.port) usePort = cfg.port;
-  }
-  // fallback default
-  if (typeof usePort === "undefined" || usePort === null) usePort = 3000;
+  // read existing persisted config
+  const cfg =
+    app.get && app.get("kaelum:config")
+      ? app.get("kaelum:config")
+      : app.locals && app.locals.kaelumConfig
+      ? app.locals.kaelumConfig
+      : {};
 
-  // create server and store reference for possible later use
-  const server = app.listen(usePort, () => {
-    console.log(`🚀 Kaelum server running on port ${usePort}`);
-    if (typeof cb === "function") cb();
+  // determine port precedence: explicit argument -> config -> default
+  let usePort;
+  try {
+    usePort = normalizePort(port);
+  } catch (err) {
+    throw err;
+  }
+
+  if (typeof usePort === "undefined") {
+    try {
+      usePort = normalizePort(cfg && cfg.port);
+    } catch (err) {
+      // config had invalid port — surface error
+      throw err;
+    }
+  }
+
+  if (typeof usePort === "undefined") {
+    usePort = 3000;
+  }
+
+  // ensure app.locals exists
+  app.locals = app.locals || {};
+
+  // if server already created and listening, return it (avoid double-listen)
+  const existing = app.locals._kaelum_server;
+  if (existing && existing.listening) {
+    const addr = existing.address && existing.address();
+    const runningPort = addr && addr.port ? addr.port : usePort;
+    console.warn(
+      `Kaelum start: server already running on port ${runningPort} — returning existing server instance.`
+    );
+    if (typeof cb === "function") {
+      // call callback asynchronously to emulate listen callback behaviour
+      process.nextTick(cb);
+    }
+    return existing;
+  }
+
+  // Start server and handle errors
+  let server;
+  try {
+    server = app.listen(usePort, () => {
+      console.log(`🚀 Kaelum server running on port ${usePort}`);
+      if (typeof cb === "function") cb();
+    });
+  } catch (err) {
+    // synchronous errors are rare; log and rethrow
+    console.error("Kaelum start: failed to start server:", err);
+    throw err;
+  }
+
+  // attach basic error handler for runtime listen errors (e.g., EADDRINUSE)
+  server.on("error", (err) => {
+    console.error(
+      "Kaelum server error:",
+      err && err.message ? err.message : err
+    );
   });
 
-  // keep reference if needed
-  if (!app.locals) app.locals = {};
+  // persist reference so we can check or close later
   app.locals._kaelum_server = server;
 
   return server;


### PR DESCRIPTION
This PR merges the comprehensive core refactoring work into the `meta-6-part2` branch.

**Summary of changes**
- Refactored core modules:
  - setMiddleware: tracking Kaelum-installed middlewares and safe removal; supports arrays, path mounts.
  - setConfig: merged config persistence, toggles for bodyParser/static/logs/port, safer middleware management.
  - addRoute / apiRoute: expanded validation and nested-path handling.
  - start: reads port from Kaelum config and stores server reference.
  - errorHandler: standardized JSON error responses (exposeStack option).
  - healthCheck: idempotent registration of /health.
  - redirect: safe registration and duplicate avoidance.
  - Created/updated JSDoc and improved validations.