### PR TITLE
release: v1.8.4 — fix logs format bug and add missing type overloads

### DIFF
--- a/core/setConfig.js
+++ b/core/setConfig.js
@@ -226,11 +226,12 @@ function setConfig(app, options = {}) {
       if (!morgan) {
         console.warn("Kaelum: morgan package not installed. Skipping logs.");
       } else {
-        // simple dev format by default; could be configured
-        const logger = morgan("dev");
+        // use provided format string, default to 'dev' when logs: true
+        const format = typeof options.logs === "string" ? options.logs : "dev";
+        const logger = morgan(format);
         app.locals._kaelum_logger = logger;
         app.use(logger);
-        console.log("📊 Request logging enabled (morgan).");
+        console.log(`📊 Request logging enabled (morgan: ${format}).`);
       }
     } else {
       console.log("📊 Request logging disabled.");

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,6 +103,8 @@ interface KaelumApp extends Express {
 
   /** Register RESTful API routes for a resource */
   apiRoute(resource: string, handlers: RouteHandlers): void;
+  apiRoute(resource: string, handler: RequestHandler): void;
+  apiRoute(resource: string, crud: true): void;
 
   /** Register middleware (optionally scoped to a path) */
   setMiddleware(middleware: RequestHandler | RequestHandler[]): MiddlewareEntry[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kaelum",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kaelum",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaelum",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "A minimalist Node.js framework for building web pages and APIs with simplicity and speed.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

Patch fixing a runtime bug in `setConfig` and improving TypeScript type accuracy.

## Changes

### Bug Fix — Morgan log format ignored
- **`core/setConfig.js`** — `setConfig({ logs: "combined" })` was always using `"dev"` format because the format string was hardcoded. Now correctly uses the user-provided value when it's a string, defaulting to `"dev"` only when `logs: true`

### Type Definitions
- **`index.d.ts`** — Added missing overloads for `apiRoute()`:
  - `apiRoute(resource, handler: RequestHandler)` — single function (assumes GET)
  - `apiRoute(resource, crud: true)` — CRUD shorthand generating 501 stubs
  - These signatures were already supported at runtime but missing from the type definitions

## Testing

- ✅ All **15 test suites** passed (**114 tests**)
- ✅ Non-breaking — fixes existing behavior to match documented API
