### PR TITLE
Release v1.8.7 — HealthCheck Overload & Listen Alias

### DIFF
--- a/core/healthCheck.js
+++ b/core/healthCheck.js
@@ -63,33 +63,53 @@ function routeExists(app, path, method) {
  * Register a health check endpoint on the provided Express/Kaelum app.
  * @param {Object} app - Express/Kaelum app instance
  * @param {HealthOptions|string} [opts] - options or a string path
+ * @param {HealthOptions} [extraOpts] - additional options when first arg is a string path
  * @returns {Function} the handler function created (useful for tests)
  */
-function registerHealth(app, opts = {}) {
+function registerHealth(app, opts = {}, extraOpts) {
   if (!app || typeof app.get !== "function") {
     throw new Error("Invalid app instance: cannot register health check");
   }
 
-  // allow shorthand: passing a string path
-  const options =
-    typeof opts === "string"
-      ? { path: opts }
-      : Object.assign(
-          {
-            path: DEFAULT_PATH,
-            method: "get",
-            replace: false,
-            readinessCheck: null,
-            include: {
-              uptime: true,
-              pid: true,
-              env: true,
-              timestamp: true,
-              metrics: false,
-            },
-          },
-          opts || {}
-        );
+  // allow shorthand: passing a string path with optional extra options
+  let options;
+  if (typeof opts === "string") {
+    // merge path into extra options if provided: healthCheck(app, "/status", { include: ... })
+    options = Object.assign(
+      {
+        path: DEFAULT_PATH,
+        method: "get",
+        replace: false,
+        readinessCheck: null,
+        include: {
+          uptime: true,
+          pid: true,
+          env: true,
+          timestamp: true,
+          metrics: false,
+        },
+      },
+      extraOpts || {},
+      { path: opts }
+    );
+  } else {
+    options = Object.assign(
+      {
+        path: DEFAULT_PATH,
+        method: "get",
+        replace: false,
+        readinessCheck: null,
+        include: {
+          uptime: true,
+          pid: true,
+          env: true,
+          timestamp: true,
+          metrics: false,
+        },
+      },
+      opts || {}
+    );
+  }
 
   // normalize path and method
   let p =

--- a/createApp.js
+++ b/createApp.js
@@ -116,6 +116,9 @@ function createApp() {
     app.start = function (port, cb) {
       return start(app, port, cb);
     };
+
+    /** Alias for start — familiar for Express users. */
+    app.listen = app.start;
   }
 
   /** Register routes with flexible handler objects. @param {string} routePath @param {Object|Function|Array} handlers */
@@ -153,10 +156,10 @@ function createApp() {
     };
   }
 
-  /** Register a health check endpoint. @param {string|HealthOptions} routePath @returns {KaelumApp} */
+  /** Register a health check endpoint. @param {string|HealthOptions} pathOrOpts @param {HealthOptions} [options] @returns {KaelumApp} */
   if (typeof registerHealth === "function") {
-    app.healthCheck = function (routePath = "/health") {
-      registerHealth(app, routePath);
+    app.healthCheck = function (pathOrOpts, options) {
+      registerHealth(app, pathOrOpts, options);
       return app;
     };
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,9 @@ interface KaelumApp extends Express {
   /** Start the HTTP server */
   start(port?: number, cb?: () => void): Server;
 
+  /** Alias for start — familiar for Express users */
+  listen(port?: number, cb?: () => void): Server;
+
   /** Register routes with a flexible handler object */
   addRoute(path: string, handlers: RouteHandlers | RequestHandler | RequestHandler[]): void;
 
@@ -121,6 +124,7 @@ interface KaelumApp extends Express {
   /** Register a health check endpoint */
   healthCheck(path?: string): KaelumApp;
   healthCheck(options?: HealthOptions): KaelumApp;
+  healthCheck(path: string, options: HealthOptions): KaelumApp;
 
   /** Register redirect route(s) */
   redirect(from: string, to: string, status?: number): RedirectEntry[] | null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kaelum",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kaelum",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaelum",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "A minimalist Node.js framework for building web pages and APIs with simplicity and speed.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## ✨ Release v1.8.7 — HealthCheck Overload & Listen Alias

### Summary
Improves health check flexibility and adds a DX convenience alias for starting the server.

### Changes

#### 🚀 Features

- **`healthCheck(path, options)` two-argument overload** (`core/healthCheck.js`, `createApp.js`):
  Previously, calling `healthCheck` with a string path (e.g. `app.healthCheck("/status")`) meant you couldn't also pass configuration like `include` or `readinessCheck`. Now supports:
  ```js
  app.healthCheck("/status", {
    include: { metrics: true, pid: false },
    readinessCheck: async () => ({ ok: true }),
  });