### PR TITLE
Release/v1.8.8

### DIFF
--- a/createApp.js
+++ b/createApp.js
@@ -6,7 +6,13 @@
 // - exposes existing core helpers (start, addRoute, setMiddleware, apiRoute)
 // - exposes error handler helper app.useErrorHandler()
 
-require("dotenv").config();
+// Load environment variables: env-specific file first (.env.production, etc),
+// then base .env as fallback. Existing process.env values are never overwritten.
+const dotenv = require("dotenv");
+const nodeEnv = process.env.NODE_ENV || "development";
+dotenv.config({ path: `.env.${nodeEnv}` });
+dotenv.config(); // base .env fallback (won't override existing vars)
+
 const express = require("express");
 const path = require("path");
 

--- a/createApp.js
+++ b/createApp.js
@@ -116,9 +116,6 @@ function createApp() {
     app.start = function (port, cb) {
       return start(app, port, cb);
     };
-
-    /** Alias for start — familiar for Express users. */
-    app.listen = app.start;
   }
 
   /** Register routes with flexible handler objects. @param {string} routePath @param {Object|Function|Array} handlers */

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,9 +100,6 @@ interface KaelumApp extends Express {
   /** Start the HTTP server */
   start(port?: number, cb?: () => void): Server;
 
-  /** Alias for start — familiar for Express users */
-  listen(port?: number, cb?: () => void): Server;
-
   /** Register routes with a flexible handler object */
   addRoute(path: string, handlers: RouteHandlers | RequestHandler | RequestHandler[]): void;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kaelum",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kaelum",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaelum",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "A minimalist Node.js framework for building web pages and APIs with simplicity and speed.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## 🔧 Release v1.8.8 — Listen Revert & Env-Specific Files

### Summary
Removes the `app.listen` alias introduced in v1.8.7 (preserving Express's native method) and adds support for environment-specific `.env` files.

### Changes

#### 🐛 Fix — Remove `app.listen` alias

The v1.8.7 alias (`app.listen = app.start`) overwrote Express's native `listen`, which:
- Could cause infinite recursion internally (`start.js` calls `app.listen()`)
- Removed user control over the raw Express API

**Now:**
- `app.start(port)` → Kaelum's enhanced startup (config-aware port, graceful shutdown)
- `app.listen(port)` → Express's native `listen` (unchanged, full control)

#### 🚀 Feature — `.env.{NODE_ENV}` support

Kaelum now loads environment-specific `.env` files before the base `.env`:
- `NODE_ENV=production` → loads .env.production first, then .env as fallback
- `NODE_ENV=development` → loads .env.development first, then .env as fallback

Follows the convention used by Vite, Next.js, and CRA. Existing `process.env` values are never overwritten.
